### PR TITLE
MessageServiceImpl Testing plus cleanup.

### DIFF
--- a/src/main/java/iths/theroom/entity/MessageEntity.java
+++ b/src/main/java/iths/theroom/entity/MessageEntity.java
@@ -55,7 +55,7 @@ public class MessageEntity {
 
     }
 
-    public Long getId() {
+    public long getId() {
         return id;
     }
 

--- a/src/main/java/iths/theroom/entity/RoomEntity.java
+++ b/src/main/java/iths/theroom/entity/RoomEntity.java
@@ -25,6 +25,7 @@ public class RoomEntity {
 
     public RoomEntity(){
         this.messages = new HashSet<>();
+        this.bannedUsers = new HashSet<>();
     }
 
     public RoomEntity(String roomName){

--- a/src/main/java/iths/theroom/model/MessageModel.java
+++ b/src/main/java/iths/theroom/model/MessageModel.java
@@ -18,7 +18,7 @@ public class MessageModel {
         return id;
     }
 
-    public void setId(Long id){ this.id = id; }
+    public void setId(long id){ this.id = id; }
 
     public String getUuid() {
         return uuid;

--- a/src/main/java/iths/theroom/service/MessageServiceImpl.java
+++ b/src/main/java/iths/theroom/service/MessageServiceImpl.java
@@ -84,11 +84,8 @@ public class MessageServiceImpl implements MessageService {
             throw new NotFoundException("No user found with that username");
         }
         if (roomName != null) {
-            try {
-                messages = filterByMessagesRoom(messages, roomName);
-            } catch (Exception e) {
-                throw new NotFoundException("Room not found");
-            }
+
+         messages = filterByMessagesRoom(messages, roomName);
         }
         if (count != null) {
             try {
@@ -183,7 +180,4 @@ public class MessageServiceImpl implements MessageService {
         return userFound.orElseThrow(NoSuchUserException::new);
     }
 
-    private boolean isBanned(UserEntity user, RoomEntity room){
-        return room.getBannedUsers().contains(user);
-    }
 }

--- a/src/test/java/iths/theroom/service/MessageServiceImplIntegrationTest.java
+++ b/src/test/java/iths/theroom/service/MessageServiceImplIntegrationTest.java
@@ -1,9 +1,10 @@
 package iths.theroom.service;
 
-import iths.theroom.entity.AvatarEntity;
-import iths.theroom.entity.MessageEntity;
-import iths.theroom.entity.RoomEntity;
-import iths.theroom.entity.UserEntity;
+import iths.theroom.entity.*;
+import iths.theroom.exception.BadRequestException;
+import iths.theroom.exception.NoSuchMessageException;
+import iths.theroom.exception.NoSuchUserException;
+import iths.theroom.exception.NotFoundException;
 import iths.theroom.factory.MessageFactory;
 import iths.theroom.model.MessageModel;
 import iths.theroom.pojos.MessageForm;
@@ -22,6 +23,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,6 +48,8 @@ public class MessageServiceImplIntegrationTest {
     RoomEntity roomEntity;
     MessageEntity message;
     MessageForm messageForm;
+    MessageRatingEntity messageRatingEntity;
+    Set<UserEntity> bannedUsers;
 
     @Before
     public void setUp() {
@@ -58,8 +62,104 @@ public class MessageServiceImplIntegrationTest {
 
         userEntity = new UserEntity("sven", "sve123", "sven@gmail.com"
                 , "sve123", "sven", "svensson", new HashSet<>(), new AvatarEntity(),"USER", "");
+        message.setSender(userEntity);
         roomEntity = new RoomEntity();
+        roomEntity.setRoomName("room1");
+        message.setRoomEntity(roomEntity);
+        messageRatingEntity = new MessageRatingEntity();
+        messageRatingEntity.setRating(0);
+        message.setMessageRatingEntity(messageRatingEntity);
 
+    }
+
+    @Test
+    public void constructor() {
+        MessageServiceImpl messageService2 = new MessageServiceImpl(messageRepository, userRepository, roomRepository);
+        assertThat(messageService2).isNotNull();
+    }
+
+
+    @Test
+    public void whenValidUuid_thenMessageModelShouldBeReturned() {
+        Mockito.when(messageRepository.findByUuid(message.getUuid()))
+                .thenReturn(java.util.Optional.of(message));
+
+        String content = "hello";
+        MessageModel found = messageService.getMessageByUuid("123abc");
+
+        assertThat(found.getContent())
+                .isEqualTo(content);
+    }
+
+
+    @Test
+    public void getAllMessages_returnsListOfAll() {  Mockito.when(messageRepository.findAll())
+            .thenReturn(List.of(message));
+       assertThat(messageService.getAllMessages().size()).isEqualTo(1);
+    }
+
+    @Test(expected = NoSuchUserException.class)
+    public void save_NoUserFoundThrowsException() {
+        Mockito.when(messageRepository.findByUuid(message.getUuid()))
+                .thenReturn(java.util.Optional.of(message));
+
+        Mockito.when(messageRepository.findAll())
+                .thenReturn(List.of(message));
+
+        Mockito.when(userRepository.findByUserName(Mockito.any()))
+                .thenReturn(Optional.empty());
+
+        assertThat(messageService.save(messageForm)).isInstanceOf(MessageModel.class);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void save_NoRoomFoundThrowsException() {
+        Mockito.when(messageRepository.findByUuid(message.getUuid()))
+                .thenReturn(java.util.Optional.of(message));
+
+        Mockito.when(messageRepository.findAll())
+                .thenReturn(List.of(message));
+
+        Mockito.when(userRepository.findByUserName(Mockito.any()))
+                .thenReturn(Optional.of(userEntity));
+
+        Mockito.when(roomRepository.getOneByRoomName(Mockito.any()))
+                .thenReturn(Optional.empty());
+
+        assertThat(messageService.save(messageForm)).isInstanceOf(MessageModel.class);
+    }
+
+    @Test
+    public void save_BanInUserNameBansUser() {
+        Mockito.when(messageRepository.findByUuid(message.getUuid()))
+                .thenReturn(java.util.Optional.of(message));
+
+        Mockito.when(messageRepository.findAll())
+                .thenReturn(List.of(message));
+
+        userEntity.setUserName("ban");
+        Mockito.when(userRepository.findByUserName(Mockito.any()))
+                .thenReturn(Optional.of(userEntity));
+
+        Mockito.when(roomRepository.getOneByRoomName(Mockito.any()))
+                .thenReturn(Optional.of(roomEntity));
+
+        Mockito.when(messageRepository.save(Mockito.any()))
+                .thenReturn(message);
+
+        Mockito.when(roomRepository.save(Mockito.any()))
+                .thenReturn(null);
+
+        Mockito.when(userRepository.save(Mockito.any()))
+                .thenReturn(null);
+
+        messageService.save(messageForm);
+        assertThat(roomEntity.getBannedUsers().contains(userEntity));
+
+    }
+
+    @Test
+    public void save_NormalOperations() {
         Mockito.when(messageRepository.findByUuid(message.getUuid()))
                 .thenReturn(java.util.Optional.of(message));
 
@@ -80,45 +180,91 @@ public class MessageServiceImplIntegrationTest {
 
         Mockito.when(messageRepository.save(Mockito.any()))
                 .thenReturn(message);
-
-
-
-    }
-
-
-
-
-    @Test
-    public void whenValidUuid_thenMessageModelShouldBeReturned() {
-        String content = "hello";
-        MessageModel found = messageService.getMessageByUuid("123abc");
-
-        assertThat(found.getContent())
-                .isEqualTo(content);
-    }
-
-
-    @Test
-    public void getAllMessages_returnsListOfAll() {
-       assertThat(messageService.getAllMessages().size()).isEqualTo(1);
-    }
-
-    @Test
-    public void save() {
      assertThat(messageService.save(messageForm)).isInstanceOf(MessageModel.class);
     }
 
     @Test
     public void remove() {
+        messageService.remove("123abc");
+        assertThat(1).isEqualTo(1);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void getAllMessagesFromUser_emptyResultYieldsNotFoundException() {
+        Mockito.when(messageRepository.findAll()).thenReturn(List.of());
+        messageService.getAllMessagesFromUser("sven", "room1", "1");
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void getAllMessagesFromUser_countExceededBecauseOfWrongRoomNameYieldsNotFoundException() {
+        Mockito.when(messageRepository.findAll()).thenReturn(List.of(message));
+        messageService.getAllMessagesFromUser("sven", "wrongroomname", "1");
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void getAllMessagesFromUser_countIsMoreThanReturnedMessages() {
+        Mockito.when(messageRepository.findAll()).thenReturn(List.of(message));
+        messageService.getAllMessagesFromUser("sven", "room1", "3");
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void getAllMessagesFromUser_countIsNotNumberThrowsException() {
+        Mockito.when(messageRepository.findAll()).thenReturn(List.of(message));
+        messageService.getAllMessagesFromUser("sven", "room1", "z");
     }
 
     @Test
-    public void getAllMessagesFromUser() {
+    public void getAllMessagesFromUser_NormalOperationCountLowerThanMessages() {
+        Mockito.when(messageRepository.findAll()).thenReturn(List.of(message, message));
+        assertThat(messageService.getAllMessagesFromUser("sven", "room1", "1").get(0)).isInstanceOf(MessageModel.class);
     }
 
     @Test
-    public void decreaseMessageRating() {
+    public void getAllMessagesFromUser_NormalOperation() {
+        Mockito.when(messageRepository.findAll()).thenReturn(List.of(message));
+        assertThat(messageService.getAllMessagesFromUser("sven", "room1", "1").get(0)).isInstanceOf(MessageModel.class);
     }
+
+    @Test(expected = NoSuchMessageException.class)
+    public void decreaseMessageRating_messageNotFoundThrowsException() {
+        Mockito.when(messageRepository.findByUuid(Mockito.any())).thenReturn(Optional.empty());
+        messageService.decreaseMessageRating("123", "johan");
+    }
+
+    @Test(expected = NoSuchUserException.class)
+    public void decreaseMessageRating_userNotFoundThrowsException() {
+        Mockito.when(messageRepository.findByUuid(Mockito.any())).thenReturn(Optional.of(message));
+        Mockito.when(userRepository.findByUserName(Mockito.any())).thenReturn(Optional.empty());
+        messageService.decreaseMessageRating("123", "johan");
+    }
+
+    @Test
+    public void decreaseMessageRating_normalOperations() {
+        Mockito.when(messageRepository.findByUuid(Mockito.any())).thenReturn(Optional.of(message));
+        Mockito.when(userRepository.findByUserName(Mockito.any())).thenReturn(Optional.of(userEntity));
+        assertThat(messageService.decreaseMessageRating("123abc", "sven").getRating()).isEqualTo(-1);
+    }
+
+    @Test(expected = NoSuchMessageException.class)
+    public void increaseMessageRating_messageNotFoundThrowsException() {
+        Mockito.when(messageRepository.findByUuid(Mockito.any())).thenReturn(Optional.empty());
+        messageService.increaseMessageRating("123", "johan");
+    }
+
+    @Test(expected = NoSuchUserException.class)
+    public void increaseMessageRating_userNotFoundThrowsException() {
+        Mockito.when(messageRepository.findByUuid(Mockito.any())).thenReturn(Optional.of(message));
+        Mockito.when(userRepository.findByUserName(Mockito.any())).thenReturn(Optional.empty());
+        messageService.increaseMessageRating("123", "johan");
+    }
+
+    @Test
+    public void increaseMessageRating_normalOperations() {
+        Mockito.when(messageRepository.findByUuid(Mockito.any())).thenReturn(Optional.of(message));
+        Mockito.when(userRepository.findByUserName(Mockito.any())).thenReturn(Optional.of(userEntity));
+        assertThat(messageService.increaseMessageRating("123abc", "sven").getRating()).isEqualTo(1);
+    }
+
 
     @Test
     public void increaseMessageRating() {


### PR DESCRIPTION
Remove unused method isbanned.
Add this.bannedUsers = new HashSet<>(); in room noargsconstructor to prevent nullpointer.
Messagemodel setId takes long.
Remove unreachable try catch in getAllMessagesFrom user. (returns empty list if no rooms found)
MessageServiceImpl coverage 100 %.